### PR TITLE
TDHome.vueのコンポーネントの配置とbodyのmargin/padding削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>to-do-list</title>
   </head>
@@ -14,3 +17,10 @@
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>
+
+<style>
+  * {
+    margin: 0px;
+    padding: 0px;
+  }
+</style>

--- a/src/components/TDAddButton/TDAddButton.vue
+++ b/src/components/TDAddButton/TDAddButton.vue
@@ -22,7 +22,7 @@ const emit = defineEmits<{
       alt="追加ボタン"
       class="_add_button"
       @click="emit('click')"
-      v-if="deleteMode"
+      v-if="!deleteMode"
     />
   </div>
 </template>

--- a/src/components/TDToDoList/TDToDoList.vue
+++ b/src/components/TDToDoList/TDToDoList.vue
@@ -70,13 +70,16 @@ function toggle(index: number) {
         :src="props.trashSrc"
         alt="ゴミ箱アイコン"
         class="_trash_icon"
-        v-if="!props.deleteMode"
+        v-if="props.deleteMode"
       />
     </button>
   </div>
 </template>
 
 <style scoped lang="sass">
+body
+  margin: 0
+  padding: 0
 button
   margin: 0
   padding: 0
@@ -117,4 +120,7 @@ button
   box-sizing: border-box
   &.is-completed
     color: #BBBBBB
+._trash_icon
+  width: 18px
+  height: 20px
 </style>

--- a/src/components/TDTrashButton/TDTrashButton.vue
+++ b/src/components/TDTrashButton/TDTrashButton.vue
@@ -23,7 +23,12 @@ const onToggle = () => {
 </script>
 
 <template>
-  <button type="button" @click="onToggle" class="_trash_button" :class="{ _delete_icon: deletemode }">
+  <button
+    type="button"
+    @click="onToggle"
+    class="_trash_button"
+    :class="{ _delete_icon: deletemode }"
+  >
     <img
       :src="deletemode ? props.deleteIconSrc : props.normalIconSrc"
       alt="ゴミ箱のアイコン"
@@ -33,8 +38,12 @@ const onToggle = () => {
 
 <style scoped lang="sass">
 ._trash_button
+  display: grid
+  justify-self: end
   background: white
   padding: 3px
+  height: 25px
+  width: 25px
 button
   margin: 0
   padding: 0

--- a/src/pages/TDHome.vue
+++ b/src/pages/TDHome.vue
@@ -2,6 +2,7 @@
 import { ref } from "vue";
 import TDMainMark from "@/components/TDMainMark/TDMainMark.vue";
 import TDToDoList from "@/components/TDToDoList/TDToDoList.vue";
+import TDAddButton from "@/components/TDAddButton/TDAddButton.vue";
 
 // ToDoList.vueからのToDoアイテムの型定義
 type ToDoItem = {
@@ -12,9 +13,11 @@ type ToDoItem = {
 // ToDoList.vueからのToDoリストのデータを保持するref
 const toDoList = ref<ToDoItem[]>([]);
 
+const deleteMode = ref(false);
+
 const addToDoList = () => {
   toDoList.value.push({
-    text: `新人研修タスク${toDoList.value.length + 1}`,
+    text: "",
     completed: false,
   });
 };
@@ -22,26 +25,55 @@ import TDTrashButton from "@/components/TDTrashButton/TDTrashButton.vue";
 </script>
 
 <template>
-  <h1>このページはTDHome.vueです。</h1>
-  <button @click="$router.push('/login')">Logoutする</button>
-  <TDMainMark src="images/TDMainMark.svg" />
-  <TDTrashButton
-    normalIconSrc="/images/TDOffTrashButton.svg"
-    deleteIconSrc="/images/TDOnTrashButton.svg"
-  />
-  <button @click="addToDoList">ToDoList追加</button>
+  <div class="_header">
+    <div class="_header_icon">
+      <TDMainMark src="images/TDMainMark.svg" />
+    </div>
+    <TDTrashButton
+      normalIconSrc="/images/TDOffTrashButton.svg"
+      deleteIconSrc="/images/TDOnTrashButton.svg"
+      @click="deleteMode = !deleteMode"
+    />
+  </div>
   <div class="_todo_list_container">
     <TDToDoList
       trashSrc="images/TDToDoListIcon.svg"
       checkedSrc="images/TDToDoListCheckedIcon.svg"
       uncheckedSrc="images/TDToDoListUncheckedIcon.svg"
       v-model="toDoList"
+      :deleteMode="deleteMode"
     />
   </div>
+  <TDAddButton
+    src="images/TDAddButton.svg"
+    :deleteMode="deleteMode"
+    @click="addToDoList"
+  />
+  <button @click="$router.push('/login')">Logoutする</button>
 </template>
 
 <style scoped lang="sass">
+body
+  margin: 0
+  padding: 0
+._header
+  display: grid
+  place-items: center
+  justify-content: space-between
+  grid-template-columns: 1fr 1fr
+  margin: 48px 24px 24px 16px
+._header_icon
+  height: 54px
+  width: 54px
+  display: grid
+  justify-self: start
+  overflow: hidden
+  :is(img, svg)
+    width: 100%
+    height: 100%
+    object-fit: contain
+    display: block
 ._todo_list_container
-  width: calc(100% - 24px) //24px分の余白を取る
+  width: calc(100% - 48px) //48px分の余白を取る
   margin: 4px auto // 中央寄せ
 </style>

--- a/src/pages/testComponent.vue
+++ b/src/pages/testComponent.vue
@@ -5,14 +5,6 @@ import TDToDoList from "@/components/TDToDoList/TDToDoList.vue";
 import TDTrashButton from "@/components/TDTrashButton/TDTrashButton.vue";
 import TDAddButton from "@/components/TDAddButton/TDAddButton.vue";
 
-withDefaults(
-  defineProps<{
-    test?: string;
-  }>(),
-  {
-    test: "ボタン",
-  }
-);
 const email = ref("");
 const pass = ref("");
 const error = ref("");
@@ -47,6 +39,7 @@ const toDoList = ref<ToDoItem[]>([]);
     <TDTrashButton
       normalIconSrc="/images/TDOffTrashButton.svg"
       deleteIconSrc="/images/TDOnTrashButton.svg"
+      @click="deleteMode = !deleteMode"
     />
     <TDErrorMessage :errorMessage="error" />
     <input type="text" v-model="email" />


### PR DESCRIPTION
fixed #24 

TDHome.vueのコンポーネントの配置とbodyのmargin/padding削除いたしました。
http://localhost:5173/home
にてご確認をお願いいたします。
※＋ボタンの下にある『logoutする」ボタンはテスト用ボタンです。

- [x] ゴミ箱ボタンをクリックするとリスト毎の右側にゴミ箱ボタンが表示される
- [x] ToDoリストの入力箇所がレスポンシブ対応
- [x] ＋ボタンクリックでToDoリストが新規作成される
- [x] bodyによる余白がない