### PR TITLE
【toDoList - 新規】autocomplete機能の実装

### DIFF
--- a/src/components/TDInput/TDInput.vue
+++ b/src/components/TDInput/TDInput.vue
@@ -21,6 +21,7 @@ const data = defineProps<InputData>();
       <label for="email" class="_email_label">メールアドレス</label>
       <input
         type="email"
+        autocomplete="email username"
         id="email"
         name="email"
         v-model="value"
@@ -38,6 +39,7 @@ const data = defineProps<InputData>();
       <label for="password" class="_password_label">パスワード</label>
       <input
         :type="visible ? 'text' : 'password'"
+        autocomplete="password"
         id="password"
         name="password"
         v-model="value"

--- a/src/pages/TDLogin.vue
+++ b/src/pages/TDLogin.vue
@@ -19,10 +19,21 @@ const router = useRouter();
 
 const login = async (): Promise<void> => {
   error.value = "";
+  visible.value = false;
   try {
     await signInWithEmailAndPassword(auth, email.value, password.value);
-    //ログイン成功後、Homeに遷移
-    router.push("/home");
+    if ("credentials" in navigator) {
+      try {
+        // @ts-ignore  // lib.dom が有効なら不要
+        const cred = new PasswordCredential({
+          id: email.value,
+          password: password.value,
+        });
+        // @ts-ignore
+        await navigator.credentials.store(cred);
+      } catch {}
+    }
+    setTimeout(() => router.push("/home"), 120);
   } catch (e: any) {
     error.value = "ログインIDまたはパスワードに誤りがあります";
   } finally {


### PR DESCRIPTION
fixed #37 

ログイン画面の入力欄にパスワードマネージャに保存されたメールアドレスとパスワードが自動で入力されるように設定いたしました。
http://localhost:5173/login
にてご確認をお願いいたします。
テスト用メールアドレス：todolist-test2@example.com
テスト用パスワード：test1231232

- [x] テスト用のメールアドレス・パスワードにてログイン後、パスワードマネージャーに入力したメールアドレスとパスワードを保存するか求められ、保存してからログアウト後、ログイン画面にて保存したメールアドレスとパスワードが自動入力されている。
