### PR TITLE
v-bindによる親から受け取ったスタイルの適応

### DIFF
--- a/src/components/TDMainMark/TDMainMark.vue
+++ b/src/components/TDMainMark/TDMainMark.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-withDefaults(
+const props = withDefaults(
   defineProps<{
     src: string;
+    height?: string;
+    width?: string;
   }>(),
   {
     src: "/images/TDMainMark.svg",
@@ -10,5 +12,11 @@ withDefaults(
 </script>
 
 <template>
-  <img :src="src" alt="メインロゴ" />
+  <img :src="src" alt="メインロゴ" class="_main_logo" />
 </template>
+
+<style scoped lang="sass">
+._main_logo
+  width: v-bind('props.width')
+  height: v-bind('props.height')
+</style>

--- a/src/pages/TDHome.vue
+++ b/src/pages/TDHome.vue
@@ -139,7 +139,7 @@ const logout = async (): Promise<void> => {
 <template>
   <div class="_header">
     <div class="_header_icon">
-      <TDMainMark src="images/TDMainMark.svg" />
+      <TDMainMark src="images/TDMainMark.svg" height="54px" width="54px" />
     </div>
     <TDTrashButton
       normalIconSrc="/images/TDOffTrashButton.svg"
@@ -183,14 +183,10 @@ const logout = async (): Promise<void> => {
   grid-template-columns: 1fr 1fr
   margin: 48px 24px 24px 16px
 ._header_icon
-  height: 54px
-  width: 54px
   display: grid
   justify-self: start
   overflow: hidden
   :is(img, svg)
-    width: 100%
-    height: 100%
     object-fit: contain
     display: block
 ._todo_list_container

--- a/src/pages/TDLogin.vue
+++ b/src/pages/TDLogin.vue
@@ -36,7 +36,7 @@ console.log("現在のログイン状態:", auth.currentUser);
 
 <template>
   <div class="_main_mark_container">
-    <TDMainMark src="/images/TDMainMark.svg" />
+    <TDMainMark src="/images/TDMainMark.svg" height="115px" width="115px" />
   </div>
   <div class="_error_message_container">
     <TDErrorMessage :errorMessage="error" :error="!!error" />


### PR DESCRIPTION
fixed #46 

画像のheightとwidthを親側で指定して、子側にてその指定された値を受け取り表示させるよう修正いたしました。
http://localhost:5173/home
にてご確認をお願いいたします。
テスト用メールアドレス：todolist-test@example.com
テスト用パスワード：test123123

- [x] ホーム画面左上に表示されるメインロゴの大きさがheightとwidthが54pxの大きさで表示される。
